### PR TITLE
Refactor CI workflow to use 'uv' and update Python versions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,20 +4,24 @@ on: [push]
 
 jobs:
   build:
+    name: continuous-integration
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint
-    - name: Analysing the code with pylint
-      run: |
-        pylint $(git ls-files '*.py')
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+      - name: Add pylint
+        run: uv add pylint
+      - name: Analysing the code with pylint
+        run: |
+          uv run pylint $(git ls-files '*.py')


### PR DESCRIPTION
Updated Python versions and modified CI steps to use 'uv' for installation and pylint analysis.